### PR TITLE
Upgrade to v0.5.0 of powsybl optimizer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <properties>
         <gridsuite-dependencies.version>28</gridsuite-dependencies.version>
         <commons-lang3.version>3.9</commons-lang3.version>
-        <powsybl-open-reac.version>0.4.0</powsybl-open-reac.version>
+        <powsybl-open-reac.version>0.5.0</powsybl-open-reac.version>
         <mockito-inline.version>3.11.1</mockito-inline.version>
         <assertj.version>3.24.2</assertj.version>
         <liquibase-hibernate-package>org.gridsuite.voltageinit.server</liquibase-hibernate-package>

--- a/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitWorkerService.java
+++ b/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitWorkerService.java
@@ -12,7 +12,6 @@ import com.powsybl.commons.reporter.Report;
 import com.powsybl.commons.reporter.Reporter;
 import com.powsybl.commons.reporter.ReporterModel;
 import com.powsybl.commons.reporter.TypedValue;
-import com.powsybl.computation.CompletableFutureTask;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManagerConstants;
 import com.powsybl.network.store.client.NetworkStoreService;
@@ -77,8 +76,6 @@ public class VoltageInitWorkerService {
     private final Set<UUID> runRequests = Sets.newConcurrentHashSet();
 
     private final Lock lockRunAndCancelVoltageInit = new ReentrantLock();
-
-    private final Executor threadPool = ForkJoinPool.commonPool();
 
     @Autowired
     NotificationService notificationService;
@@ -157,7 +154,7 @@ public class VoltageInitWorkerService {
 
             OpenReacParameters parameters = voltageInitParametersService.buildOpenReacParameters(context, network);
             OpenReacConfig config = OpenReacConfig.load();
-            CompletableFuture<OpenReacResult> future = CompletableFutureTask.runAsync(() -> OpenReacRunner.run(network, network.getVariantManager().getWorkingVariantId(), parameters, config, voltageInitExecutionService.getComputationManager()), this.threadPool);
+            CompletableFuture<OpenReacResult> future = OpenReacRunner.runAsync(network, network.getVariantManager().getWorkingVariantId(), parameters, config, voltageInitExecutionService.getComputationManager());
             if (resultUuid != null) {
                 futures.put(resultUuid, future);
             }


### PR DESCRIPTION
* Upgrade to v0.5.0 of powsybl optimizer
* Fix the knitro cancellation when the voltage init calculation is stopped by using directly ```runAsync()``` from OpenReacRunner
* Remove the test for the merging view (`mergingViewTest` that was forgotten in the last migration https://github.com/gridsuite/voltage-init-server/commit/0d0e466e419a0f266aa01ffa3945c23e3aa99c8d)