### PR TITLE
Computation in debug mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
     <properties>
         <gridsuite-dependencies.version>42.0.0</gridsuite-dependencies.version>
         <!-- FIXME to remove at next upgrade of gridsuite-dependencies -->
-        <gridsuite-computation.version>1.0.0</gridsuite-computation.version>
+        <gridsuite-computation.version>1.1.0</gridsuite-computation.version>
         <!-- FIXME to remove at next upgrade of powsybl-ws-dependencies -->
-        <powsybl-ws-commons.version>1.28.0</powsybl-ws-commons.version>
+        <powsybl-ws-commons.version>1.28.1</powsybl-ws-commons.version>
         <powsybl-open-reac.version>0.14.0</powsybl-open-reac.version>
         <powsybl-optimizer-commons.version>0.13.0</powsybl-optimizer-commons.version>
         <mockwebserver3.version>5.0.0-alpha.14</mockwebserver3.version>

--- a/src/main/java/org/gridsuite/voltageinit/server/VoltageInitController.java
+++ b/src/main/java/org/gridsuite/voltageinit/server/VoltageInitController.java
@@ -51,9 +51,10 @@ public class VoltageInitController {
                                            @Parameter(description = "reportUuid") @RequestParam(name = "reportUuid", required = false) UUID reportUuid,
                                            @Parameter(description = "reporterId") @RequestParam(name = "reporterId", required = false) String reporterId,
                                            @Parameter(description = "The type name for the report") @RequestParam(name = "reportType", required = false, defaultValue = "VoltageInit") String reportType,
+                                           @Parameter(description = "Debug") @RequestParam(name = "debug", required = false, defaultValue = "false") boolean debug,
                                            @Parameter(description = "parametersUuid") @RequestParam(name = "parametersUuid", required = false) UUID parametersUuid,
                                            @RequestHeader(HEADER_USER_ID) String userId) {
-        VoltageInitRunContext runContext = new VoltageInitRunContext(networkUuid, variantId, receiver, reportUuid, reporterId, reportType, userId, parametersUuid);
+        VoltageInitRunContext runContext = new VoltageInitRunContext(networkUuid, variantId, receiver, reportUuid, reporterId, reportType, userId, parametersUuid, debug);
         UUID resultUuid = voltageInitService.runAndSaveResult(runContext);
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(resultUuid);
     }

--- a/src/main/java/org/gridsuite/voltageinit/server/VoltageInitController.java
+++ b/src/main/java/org/gridsuite/voltageinit/server/VoltageInitController.java
@@ -11,20 +11,19 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import org.gridsuite.voltageinit.server.dto.VoltageInitResult;
 import org.gridsuite.voltageinit.server.dto.VoltageInitStatus;
 import org.gridsuite.voltageinit.server.service.VoltageInitRunContext;
 import org.gridsuite.voltageinit.server.service.VoltageInitService;
+import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.UUID;
-
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
 
 import static org.gridsuite.computation.service.NotificationService.HEADER_USER_ID;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -123,5 +122,13 @@ public class VoltageInitController {
     public ResponseEntity<Void> resetModificationsGroupUuidInResult(@Parameter(description = "Result UUID") @PathVariable("resultUuid") UUID resultUuid) {
         voltageInitService.resetModificationsGroupUuid(resultUuid);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(value = "/results/{resultUuid}/download-debug-file", produces = "application/json")
+    @Operation(summary = "Download a voltage init debug file")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Voltage init debug file"),
+        @ApiResponse(responseCode = "404", description = "Voltage init debug file has not been found")})
+    public ResponseEntity<Resource> downloadDebugFile(@Parameter(description = "Result UUID") @PathVariable("resultUuid") UUID resultUuid) {
+        return voltageInitService.downloadDebugFile(resultUuid);
     }
 }

--- a/src/main/java/org/gridsuite/voltageinit/server/entities/VoltageInitResultEntity.java
+++ b/src/main/java/org/gridsuite/voltageinit/server/entities/VoltageInitResultEntity.java
@@ -6,24 +6,16 @@
  */
 package org.gridsuite.voltageinit.server.entities;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
-
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * @author Ayoub LABIDI <ayoub.labidi at rte-france.com>
@@ -62,4 +54,7 @@ public class VoltageInitResultEntity {
 
     @Column
     private Double reactiveSlacksThreshold;
+
+    @Column(name = "debug_file_location")
+    private String debugFileLocation;
 }

--- a/src/main/java/org/gridsuite/voltageinit/server/repository/ResultRepository.java
+++ b/src/main/java/org/gridsuite/voltageinit/server/repository/ResultRepository.java
@@ -6,12 +6,15 @@
  */
 package org.gridsuite.voltageinit.server.repository;
 
-import java.util.Optional;
-import java.util.UUID;
-
 import org.gridsuite.voltageinit.server.entities.VoltageInitResultEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * @author Ayoub LABIDI <ayoub.labidi at rte-france.com>
@@ -23,4 +26,8 @@ public interface ResultRepository extends JpaRepository<VoltageInitResultEntity,
     Optional<VoltageInitResultEntity> findByResultUuid(UUID resultUuid);
 
     void deleteByResultUuid(UUID resultUuid);
+
+    @Modifying
+    @Query("UPDATE VoltageInitResultEntity r SET r.debugFileLocation = :debugFileLocation WHERE r.resultUuid = :resultUuid")
+    int updateDebugFileLocation(@Param("resultUuid") UUID resultUuid, @Param("debugFileLocation") String debugFileLocation);
 }

--- a/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitResultContext.java
+++ b/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitResultContext.java
@@ -18,8 +18,7 @@ import org.springframework.messaging.MessageHeaders;
 import java.io.UncheckedIOException;
 import java.util.*;
 
-import static org.gridsuite.computation.service.NotificationService.HEADER_RECEIVER;
-import static org.gridsuite.computation.service.NotificationService.HEADER_USER_ID;
+import static org.gridsuite.computation.service.NotificationService.*;
 
 /**
  * @author Etienne Homer <etienne.homer at rte-france.com>
@@ -51,6 +50,7 @@ public class VoltageInitResultContext extends AbstractResultContext<VoltageInitR
         String variantId = (String) headers.get(VARIANT_ID_HEADER);
         String receiver = (String) headers.get(HEADER_RECEIVER);
         String userId = (String) headers.get(HEADER_USER_ID);
+        Boolean debug = (Boolean) headers.get(HEADER_DEBUG);
         Map<String, Double> voltageLevelsIdsRestricted;
         try {
             voltageLevelsIdsRestricted = headers.get(VOLTAGE_LEVELS_IDS_RESTRICTED) != null ?
@@ -68,8 +68,7 @@ public class VoltageInitResultContext extends AbstractResultContext<VoltageInitR
         String reporterId = headers.containsKey(REPORTER_ID_HEADER) ? (String) headers.get(REPORTER_ID_HEADER) : null;
         String reportType = headers.containsKey(REPORT_TYPE_HEADER) ? (String) headers.get(REPORT_TYPE_HEADER) : null;
         VoltageInitRunContext runContext = new VoltageInitRunContext(
-                networkUuid, variantId, receiver, reportUuid, reporterId, reportType, userId, parametersUuid, voltageLevelsIdsRestricted
-        );
+                networkUuid, variantId, receiver, reportUuid, reporterId, reportType, userId, parametersUuid, voltageLevelsIdsRestricted, debug);
         return new VoltageInitResultContext(resultUuid, runContext);
     }
 

--- a/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitResultService.java
+++ b/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitResultService.java
@@ -7,6 +7,7 @@
 package org.gridsuite.voltageinit.server.service;
 
 import com.powsybl.iidm.network.Bus;
+import com.powsybl.openreac.parameters.output.OpenReacResult;
 import org.gridsuite.computation.service.AbstractComputationResultService;
 import org.gridsuite.voltageinit.server.dto.VoltageInitStatus;
 import org.gridsuite.voltageinit.server.entities.BusVoltageEmbeddable;
@@ -19,14 +20,8 @@ import org.jgrapht.alg.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.powsybl.openreac.parameters.output.OpenReacResult;
-
 import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -64,7 +59,7 @@ public class VoltageInitResultService extends AbstractComputationResultService<V
             }
         ).filter(Objects::nonNull).toList();
         return new VoltageInitResultEntity(resultUuid, Instant.now(), indicators, reactiveSlacks, busVoltages, modificationsGroupUuid,
-                                           isReactiveSlacksOverThreshold, reactiveSlacksThreshold);
+                                           isReactiveSlacksOverThreshold, reactiveSlacksThreshold, null);
     }
 
     @Override
@@ -129,6 +124,25 @@ public class VoltageInitResultService extends AbstractComputationResultService<V
     @Transactional
     public void insertErrorResult(UUID resultUuid, Map<String, String> errorIndicators) {
         Objects.requireNonNull(resultUuid);
-        resultRepository.save(new VoltageInitResultEntity(resultUuid, Instant.now(), errorIndicators, List.of(), List.of(), null, false, null));
+        resultRepository.save(new VoltageInitResultEntity(resultUuid, Instant.now(), errorIndicators, List.of(), List.of(), null, false, null, null));
+    }
+
+    @Override
+    @Transactional
+    public void saveDebugFileLocation(UUID resultUuid, String debugFilePath) {
+        resultRepository.findById(resultUuid).ifPresentOrElse(
+                (var resultEntity) -> resultRepository.updateDebugFileLocation(resultUuid, debugFilePath),
+                () -> resultRepository.save(new VoltageInitResultEntity(resultUuid, null, null, null, null, null,
+                        false, null, debugFilePath))
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String findDebugFileLocation(UUID resultUuid) {
+        Objects.requireNonNull(resultUuid);
+        return resultRepository.findById(resultUuid)
+                .map(VoltageInitResultEntity::getDebugFileLocation)
+                .orElse(null);
     }
 }

--- a/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitRunContext.java
+++ b/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitRunContext.java
@@ -24,15 +24,16 @@ public class VoltageInitRunContext extends AbstractComputationRunContext<Void> {
 
     private final Map<String, Double> voltageLevelsIdsRestricted;
 
-    public VoltageInitRunContext(UUID networkUuid, String variantId, String receiver, UUID reportUuid, String reporterId, String reportType, String userId, UUID parametersUuid, Map<String, Double> voltageLevelsIdsRestricted) {
+    public VoltageInitRunContext(UUID networkUuid, String variantId, String receiver, UUID reportUuid, String reporterId,
+             String reportType, String userId, UUID parametersUuid, Map<String, Double> voltageLevelsIdsRestricted, Boolean debug) {
         super(networkUuid, variantId, receiver, new ReportInfos(reportUuid, reporterId, reportType), userId,
             "default-provider",  // TODO : replace with null when fix in powsybl-ws-commons will handle null provider
-            null);
+            null, debug);
         this.parametersUuid = parametersUuid;
         this.voltageLevelsIdsRestricted = voltageLevelsIdsRestricted;
     }
 
     public VoltageInitRunContext(UUID networkUuid, String variantId, String receiver, UUID reportUuid, String reporterId, String reportType, String userId, UUID parametersUuid) {
-        this(networkUuid, variantId, receiver, reportUuid, reporterId, reportType, userId, parametersUuid, new HashMap<>());
+        this(networkUuid, variantId, receiver, reportUuid, reporterId, reportType, userId, parametersUuid, new HashMap<>(), null);
     }
 }

--- a/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitRunContext.java
+++ b/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitRunContext.java
@@ -33,7 +33,7 @@ public class VoltageInitRunContext extends AbstractComputationRunContext<Void> {
         this.voltageLevelsIdsRestricted = voltageLevelsIdsRestricted;
     }
 
-    public VoltageInitRunContext(UUID networkUuid, String variantId, String receiver, UUID reportUuid, String reporterId, String reportType, String userId, UUID parametersUuid) {
-        this(networkUuid, variantId, receiver, reportUuid, reporterId, reportType, userId, parametersUuid, new HashMap<>(), null);
+    public VoltageInitRunContext(UUID networkUuid, String variantId, String receiver, UUID reportUuid, String reporterId, String reportType, String userId, UUID parametersUuid, Boolean debug) {
+        this(networkUuid, variantId, receiver, reportUuid, reporterId, reportType, userId, parametersUuid, new HashMap<>(), debug);
     }
 }

--- a/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitService.java
+++ b/src/main/java/org/gridsuite/voltageinit/server/service/VoltageInitService.java
@@ -8,8 +8,8 @@ package org.gridsuite.voltageinit.server.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.network.store.client.NetworkStoreService;
-
 import org.gridsuite.computation.dto.GlobalFilter;
+import org.gridsuite.computation.s3.ComputationS3Service;
 import org.gridsuite.computation.service.AbstractComputationService;
 import org.gridsuite.computation.service.NotificationService;
 import org.gridsuite.computation.service.UuidGeneratorService;
@@ -45,9 +45,11 @@ public class VoltageInitService extends AbstractComputationService<VoltageInitRu
                               NetworkModificationService networkModificationService,
                               UuidGeneratorService uuidGeneratorService,
                               VoltageInitResultService resultService,
+                              @Autowired(required = false)
+                              ComputationS3Service computationS3Service,
                               FilterService filterService,
                               ObjectMapper objectMapper) {
-        super(notificationService, resultService, objectMapper, uuidGeneratorService, null);
+        super(notificationService, resultService, computationS3Service, objectMapper, uuidGeneratorService, null);
         this.networkModificationService = Objects.requireNonNull(networkModificationService);
         this.filterService = Objects.requireNonNull(filterService);
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,6 +4,9 @@ server:
 spring:
   rabbitmq:
     addresses: localhost
+  cloud:
+    aws:
+      endpoint: http://localhost:19000
 
 powsybl-ws:
   database:

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -15,6 +15,8 @@ spring:
             max-attempts: 1
         publishRun-out-0:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}voltageinit.run
+        publishDebug-out-0:
+          destination: ${powsybl-ws.rabbitmq.destination.prefix:}voltageinit.debug
         publishResult-out-0:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}voltageinit.result
         consumeCancel-in-0:
@@ -25,7 +27,7 @@ spring:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}voltageinit.stopped
         publishCancelFailed-out-0:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}voltageinit.cancelfailed
-      output-bindings: publishRun-out-0;publishResult-out-0;publishCancel-out-0;publishStopped-out-0;publishCancelFailed-out-0
+      output-bindings: publishRun-out-0;publishDebug-out-0;publishResult-out-0;publishCancel-out-0;publishStopped-out-0;publishCancelFailed-out-0
       rabbit:
         bindings:
           consumeRun-in-0:
@@ -37,6 +39,12 @@ spring:
               quorum:
                 enabled: true
                 delivery-limit: 2
+
+computation:
+  s3:
+    enabled: false
+
+debug-subpath: debug
 
 powsybl-ws:
   database:

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -42,7 +42,7 @@ spring:
 
 computation:
   s3:
-    enabled: false
+    enabled: true
 
 debug-subpath: debug
 

--- a/src/main/resources/db/changelog/changesets/changelog_20250801T132858Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20250801T132858Z.xml
@@ -1,0 +1,10 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="phamquy (generated)" id="1754054948453-5">
+        <addColumn tableName="voltage_init_result">
+            <column name="debug_file_location" type="varchar(255)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -42,3 +42,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20250711T130602Z.xml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20250801T132858Z.xml
+      relativeToChangelogFile: true

--- a/src/test/java/org/gridsuite/voltageinit/server/service/parameters/ParametersTest.java
+++ b/src/test/java/org/gridsuite/voltageinit/server/service/parameters/ParametersTest.java
@@ -148,7 +148,7 @@ class ParametersTest {
         final VoltageInitParametersEntity voltageInitParameters = entityManager.persistFlushFind(
             new VoltageInitParametersEntity(null, null, "", voltageLimits, null, EquipmentsSelectionType.ALL_EXCEPT, null, EquipmentsSelectionType.NONE_EXCEPT, null, EquipmentsSelectionType.NONE_EXCEPT, 100., 0., false)
         );
-        final VoltageInitRunContext context = new VoltageInitRunContext(NETWORK_UUID, VARIANT_ID_1, null, REPORT_UUID, null, "", "", voltageInitParameters.getId());
+        final VoltageInitRunContext context = new VoltageInitRunContext(NETWORK_UUID, VARIANT_ID_1, null, REPORT_UUID, null, "", "", voltageInitParameters.getId(), false);
         context.setReportNode(ReportNode.newRootReportNode()
                 .withResourceBundles("i18n.reports")
                 .withMessageTemplate(COMPUTATION_TYPE).build());
@@ -261,7 +261,7 @@ class ParametersTest {
             new VoltageInitParametersEntity(null, null, "", List.of(vl1, vl2, vl3, vl4), null, EquipmentsSelectionType.ALL_EXCEPT, null, EquipmentsSelectionType.NONE_EXCEPT, null, EquipmentsSelectionType.NONE_EXCEPT, 100., 0., false)
         );
 
-        final VoltageInitRunContext context = new VoltageInitRunContext(networkUuid, variantId, null, REPORT_UUID, null, "", "", voltageInitParameters.getId());
+        final VoltageInitRunContext context = new VoltageInitRunContext(networkUuid, variantId, null, REPORT_UUID, null, "", "", voltageInitParameters.getId(), false);
         context.setReportNode(ReportNode.newRootReportNode()
                 .withResourceBundles("i18n.reports")
                 .withMessageTemplate("VoltageInit").build());


### PR DESCRIPTION
When a launch is performed with the debug option enabled, a debug directory (i.e., debugDir) is always created. Each computation must then pass this debugDir to the Powsybl layer via its computation parameters, for example [see code](https://github.com/gridsuite/voltage-init-server/pull/117/files#diff-c26b731d59ddf91c50daea8909bdeecf37aee5b8eda29e507b5c1c1d330a02b9R95-R97).

At the Powsybl level (see [see code](https://github.com/powsybl/powsybl-core/pull/3455/files#diff-adba10585c9d7ca9b705c20b2625dccd13a87b48fd115b6cc87159d96a0ac731R208)), if debugDir is provided, then at the end of the computation, all files from the working directory are systematically copied into the debug directory. Typically, there is always something to copy (for binary computations, at minimum the result is exported. For Java computations, logs are generated due to the presence of debugDir in the parameters.).

In some cases, the working directory may be empty, for example, if an exception was thrown early in the process, but the debug directory is still always zipped and uploaded to S3.